### PR TITLE
Fixed port parsing and http/https connections

### DIFF
--- a/jellfin-cWeb2/Package.appxmanifest
+++ b/jellfin-cWeb2/Package.appxmanifest
@@ -45,5 +45,6 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer"/>
   </Capabilities>
 </Package>


### PR DESCRIPTION
Previously, if a port was part of the entered address, it would be stripped and the default ports would be used for http/https. This was changed to only use the default ports if there is no port is specified.

Previously, an https connection was attempted and a http connection was attempted in CheckURLValidAsync, and CheckURLValidAsync was called twice. If the first http connection succeeded, CheckURLValidAsync would return true even though the scheme of the uri that was attempted was https. Now, CheckURLValidAsync only attempts one connection per call and is called once for https and once for http in NormalizeAndCheckUri.